### PR TITLE
Update usage with dotenv

### DIFF
--- a/branch-protection/README.md
+++ b/branch-protection/README.md
@@ -16,13 +16,20 @@ Helps setup a master branch protection policy by setting:
 
 ## Setup
 
-Modify the scripts 'essential settings' section with your personal access token, team name for reviews etc. and quickly review the 'optional tweaks'.
+Provide a `.env` file in the root directory with the contents of `.env-sample`. They make the 'essential settings' and include your personal access token (repo level permission), team name for reviews, etc.
 
 ```javascript
-// Essential settings - change these as we can't have defaults
-const personalAccessToken = 'your personal access token';
-const reviewTeams = [ 'your-team' ];
+GITHUB_API_TOKEN=82832askd9knsia42dbueiabdi2asndpasd1wwe
+REVIEW_TEAM_NAME=dx-sdks-approver
+YOUR_GITHUB_NAME=damieng
+YOUR_GITHUB_EMAIL=damien.guard@auth0.com
+```
 
+Do note the team name does not prefix the organization.
+
+There are also additional but optional tweaks you can change
+
+```javascript
 // Optional tweaks - these are sensible defaults
 const gitHubUrl = 'github.com'; // Change this if GitHub Enterprise
 const dismissTeams = reviewTeams;
@@ -30,7 +37,7 @@ const copyChecksFromRef = [ 'master' ];
 const daysPriorWithSuccessfulChecks = 30;
 ```
 
-If you wish to change the settings simply change the object around line 45 to set the settings you want or do not want.
+If you wish to change the settings simply change the object around line 50 to set the settings you want or do not want.
 
 ## Running
 

--- a/branch-protection/app.js
+++ b/branch-protection/app.js
@@ -1,9 +1,10 @@
 const Octokit = require('@octokit/rest');
 const cp = require('child_process');
+require('dotenv').config({ path: '../.env' })
 
 // Essential settings - change these as we can't have defaults
-const personalAccessToken = 'your personal access token';
-const reviewTeams = [ 'your-team' ];
+const personalAccessToken = process.env.GITHUB_API_TOKEN;
+const reviewTeams = [ process.env.REVIEW_TEAM_NAME ];
 
 // Optional tweaks - these are sensible defaults
 const gitHubUrl = 'github.com'; // Change this if GitHub Enterprise

--- a/branch-protection/package.json
+++ b/branch-protection/package.json
@@ -9,6 +9,7 @@
   "author": "Damien Guard <damieng@gmail.com>",
   "license": "MIT",
   "dependencies": {
-    "@octokit/rest": "^16.25.1"
+    "@octokit/rest": "^16.25.1",
+    "dotenv": "^8.2.0"
   }
 }

--- a/pr-process/README.md
+++ b/pr-process/README.md
@@ -9,19 +9,18 @@ Helps setup a Pull Review process by:
 
 ## Setup
 
-Modify the scripts 'essential settings' section with your personal access token (repo level permission), team name for reviews etc.
+Provide a `.env` file in the root directory with the contents of `.env-sample`. They make the 'essential settings' and include your personal access token (repo level permission), team name for reviews, etc.
 
 ```javascript
-// Essential settings - change these as we can't have defaults
-const personalAccessToken = 'your personal access token';
-const reviewTeam = '@your-org/@your-team';
-const committer = {
-    name: 'Your Name',
-    email: 'Your Email'
-};
+GITHUB_API_TOKEN=82832askd9knsia42dbueiabdi2asndpasd1wwe
+REVIEW_TEAM_NAME=dx-sdks-approver
+YOUR_GITHUB_NAME=damieng
+YOUR_GITHUB_EMAIL=damien.guard@auth0.com
 ```
 
-If you wish to use multiple reviewers or individuals rather than teams you'll need to modify the script - specifically the lines that create the codeowners file (one individual/team per line) and the line that creates the PR to merge it in - array and/or switching from team_approvers to approvers.
+Do note the team name does not prefix the organization.
+
+If you wish to use multiple reviewers or individuals rather than teams you'll need to modify the script - specifically the lines that create the CODEOWNERS file (one individual/team per line) and the line that creates the PR to merge it in - array and/or switching from team_approvers to approvers.
 
 ## Running
 

--- a/pr-process/package.json
+++ b/pr-process/package.json
@@ -9,7 +9,7 @@
   "author": "Damien Guard <damieng@gmail.com>",
   "license": "MIT",
   "dependencies": {
-    "@octokit/rest": "github:octokit/rest.js",
+    "@octokit/rest": "^16.43.1",
     "dotenv": "^8.2.0"
   }
 }

--- a/stale-config/README.md
+++ b/stale-config/README.md
@@ -7,12 +7,16 @@ Helps setup [Probot:Stale](https://github.com/probot/stale) by:
 
 ## Setup
 
-Modify the scripts 'essential settings' section with your personal access token (repo level permission) and the included stale.yml that will be checked in to the repo.
+Provide a `.env` file in the root directory with the contents of `.env-sample`. They make the 'essential settings' and include your personal access token (repo level permission), team name for reviews, etc. 
 
 ```javascript
-// Essential settings - change these as we can't have defaults
-const personalAccessToken = '';
+GITHUB_API_TOKEN=82832askd9knsia42dbueiabdi2asndpasd1wwe
+REVIEW_TEAM_NAME=dx-sdks-approver
+YOUR_GITHUB_NAME=damieng
+YOUR_GITHUB_EMAIL=damien.guard@auth0.com
 ```
+
+Then include the `stale.yml` fuke that will be checked in to the repo.
 
 ## Running
 


### PR DESCRIPTION
Updates the README files to show usage by only setting a `.env` file in the root of the project. Bumps the dependencies of oktokit (one was fixed to a github branch) and clarify that the team name must not prefix the organization name.