### PR TITLE
Handle CODEOWNERS existing branch and same content

### DIFF
--- a/pr-process/package.json
+++ b/pr-process/package.json
@@ -9,7 +9,7 @@
   "author": "Damien Guard <damieng@gmail.com>",
   "license": "MIT",
   "dependencies": {
-    "@octokit/rest": "github:octokit/rest.js",
+    "@octokit/rest": "^16.43.1",
     "dotenv": "^8.2.0"
   }
 }


### PR DESCRIPTION
This PR improves the `pr-process` script in the following ways:
- Checks whether a branch already exists and if so, opens the browser and halts the script in order for the user to first delete it.
- Checks if the CODEOWNERS file already exists and has the same content, if so, it halts the script.
- Checks if the CODEOWNERS file already exists and if so, updates its contents.
- Fixes the `octokit` version to stop depending on a github branch

**In addition:**
The team name environment variable must not include the organization name. That one is set within the script from the parameters passed to the invocation. 

This is required because for the CODEOWNERS to correctly assign any new issues/prs, it requires the full team name including the organization, like this:
```
@auth0-samples/dx-sdks-approver
```

However, when the new PR created with this script is to be assigned someone on the team for review, the short hand of the team should be used, without the organization, like this:
```
dx-sdks-approver
```